### PR TITLE
Fixes QUAL-43

### DIFF
--- a/bundles/org.palladiosimulator.edp2/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.edp2/META-INF/MANIFEST.MF
@@ -33,7 +33,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.codec;bundle-version="1.4.0",
  org.palladiosimulator.measurementframework;bundle-version="1.0.0",
  org.palladiosimulator.metricspec;bundle-version="1.0.0";visibility:=reexport,
- org.palladiosimulator.edp2.dao;bundle-version="4.2.0",
+ org.palladiosimulator.edp2.dao;bundle-version="4.2.0";visibility:=reexport,
  org.palladiosimulator.commons
 Bundle-Activator: org.palladiosimulator.edp2.EDP2Plugin
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Dependency .edp2.dao was not reexported. Therefore standalone initialization of the model factory failed.

https://jira.palladio-simulator.com/projects/QUAL/issues/QUAL-43