### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.5</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.9.0</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.edp2</groupId>
 	<artifactId>parent</artifactId>	
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
-		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.edp2.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.edp2.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	
 	<modules>

--- a/releng/org.palladiosimulator.edp2.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.edp2.targetplatform/tp.target
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target name="org.palladiosimulator.edp2 Target Platform" sequenceNumber="1">
+<?pde version="3.8"?><target name="org.palladiosimulator.edp2 Target Platform" sequenceNumber="1">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0" />
-			<unit id="de.uka.ipd.sdq.dialogs.feature.feature.group" version="0.0.0" />
+			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
+			<unit id="de.uka.ipd.sdq.dialogs.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0" />
-			<unit id="de.uka.ipd.sdq.dialogs.feature.feature.group" version="0.0.0" />
+			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
+			<unit id="de.uka.ipd.sdq.dialogs.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
-		</location>	
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
 			<unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="1.0.2.201709282218"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/releases/latest/"/>
@@ -21,23 +20,23 @@
 			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0" />
+			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/releases/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0" />
+			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0" />
+			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/releases/latest/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0" />
+			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
-		</location>	
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<unit id="org.eclipse.nebula.widgets.formattedtext.feature.feature.group" version="1.0.0.201605182147" />
+			<unit id="org.eclipse.nebula.widgets.formattedtext.feature.feature.group" version="1.0.0.201605182147"/>
 			<repository location="https://archive.eclipse.org/nebula/Q22016/incubation/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">

--- a/releng/org.palladiosimulator.edp2.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.edp2.targetplatform/tp.target
@@ -1,37 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="org.palladiosimulator.edp2 Target Platform" sequenceNumber="1">
+<?pde version="3.8"?><target name="org.palladiosimulator.edp2 Target Platform" sequenceNumber="2">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
-			<unit id="de.uka.ipd.sdq.dialogs.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
 			<unit id="de.uka.ipd.sdq.dialogs.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="1.0.2.201709282218"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-			<unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="1.0.2.201709282218"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/releases/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
 		</location>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`  
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`  
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`  
- In the target platform `tp.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM  
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure  
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:  
    - Removed any `<location filter="release">` entries  
    - Removed `filter="nightly"` attributes  
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`  
  - Added indentation to improve readability